### PR TITLE
Add Bark (Ark) backend knowledge

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -19,7 +19,8 @@ Use this skill to manage an Alby Hub lightning node via the CLI.
 
 - [Installation: How to get Alby Hub running — cloud, Linux, Docker, Raspberry Pi, desktop](./references/installation.md)
 - [Overview: What Alby Hub is and how the CLI fits in](./references/overview.md)
-- [Backends: LDK, LND, Phoenixd, Cashu — features and configuration](./references/backends.md)
+- [Backends: LDK, LND, Phoenixd, Cashu, Bark — features and configuration](./references/backends.md)
+- [Bark (Ark): Setup, env-var config, and limitations of the Ark-based backend](./references/bark.md)
 - [Initial Setup: First-time hub initialisation flow](./references/initial-setup.md)
 - [Post-Setup Checklist: Things a new user should do AFTER initial setup — surface on first setup or when asked "what's next?"](./references/post-setup-checklist.md)
 - [Authentication: Token management, start, unlock, token priority](./references/authentication.md)
@@ -48,7 +49,7 @@ The CLI connects to `http://localhost:8080` by default. Override with `-u <url>`
 
 ### Default Backend
 
-LDK is the default backend. Omit `--backend` when using LDK. Only specify `--backend` for non-LDK backends (LND, Phoenixd, Cashu).
+LDK is the default backend. Omit `--backend` when using LDK. Only specify `--backend` for non-LDK backends (LND, Phoenixd, Cashu, Bark).
 
 ### Token Priority
 

--- a/references/backends.md
+++ b/references/backends.md
@@ -10,6 +10,7 @@ Alby Hub supports multiple lightning backends. The backend is chosen once during
 | `LND`      | External LND node connected via gRPC (only suggest if user mentions they already have LND installed) |
 | `PHOENIXD` | External Phoenixd node (automatic liquidity management, EXPERIMENTAL - not recommended)              |
 | `CASHU`    | Cashu e-cash wallet (no channels required, EXPERIMENTAL, CUSTODIAL - not recommended)                |
+| `BARK`     | [Ark](https://second.tech/) wallet — no channels or on-chain needed (BETA). See [Bark (Ark)](./bark.md) |
 
 ## Commands
 

--- a/references/bark.md
+++ b/references/bark.md
@@ -1,0 +1,37 @@
+# Bark (Ark)
+
+Bark is an [Ark](https://second.tech/) client backend. Instead of opening lightning channels, it connects to an **Ark server** that provides liquidity, so the user can send and receive lightning payments immediately with **no channel or on-chain management**. This is the simplest backend to get started with, but it has important trade-offs (see Limitations).
+
+> **Bark is BETA — use at your own risk.**
+
+## Setup
+
+Bark is configured entirely through environment variables read by the hub at startup — it has no CLI flags. Set the env vars on the hub **before** running `setup`. The mnemonic is generated automatically; do not pass `--mnemonic`.
+
+```bash
+npx -y @getalby/hub-cli@0.4.0 hub-cli setup --password YOUR_PASSWORD --backend BARK
+```
+
+The backend is fixed at setup time and cannot be changed afterwards without re-initialising the hub.
+
+## Configuration
+
+| Env var | Default | Purpose |
+| ------- | ------- | ------- |
+| `LN_BACKEND_TYPE` | — | Set to `BARK` (or pass `--backend BARK` to `setup`) |
+| `BARK_SERVER` | `https://ark.second.tech` | Ark server URL. For signet use `https://ark.signet.2nd.dev` |
+| `BARK_ESPLORA_SERVER` | `https://mempool.second.tech/api` | Esplora server URL for chain data. For signet use `https://esplora.signet.2nd.dev` |
+| `BARK_SERVER_ACCESS_TOKEN` | (none) | Optional — only required for a private Ark server |
+| `BARK_LOG_LEVEL` | `3` | Bark-specific log verbosity (higher is more verbose). Separate from the main app log level |
+
+## Limitations
+
+- **No channels.** Channel and peer commands (open/close/connect) are no-ops, and `list-channels` returns an empty list. Skip the LSP / channel-opening flow from [Initial Setup](./initial-setup.md) — funds are usable as soon as setup completes.
+- **No on-chain.** On-chain address, balance, and send/receive are unsupported. Swaps, keysend, HOLD invoices, BOLT-12 offers, and message signing are also unsupported.
+- **Periodic refresh fees.** Bark funds (VTXOs) are refreshed periodically, which incurs a small fee.
+- **Limited recovery.** During beta, funds **cannot be recovered from the recovery phrase alone** — the local bark wallet data directory (`<workdir>/bark`) is also required. Make sure the user backs up that directory, not just the mnemonic.
+- **Requires persistent storage.** Like Cashu, bark stores wallet state on local disk with no remote-backup mechanism, so it is **not available on Alby Cloud** or other environments without a persistent volume.
+
+## Supported NWC methods
+
+`pay_invoice`, `multi_pay_invoice`, `make_invoice`, `lookup_invoice`, `list_transactions`, `get_balance`, `get_budget`, `get_info`.

--- a/references/initial-setup.md
+++ b/references/initial-setup.md
@@ -54,7 +54,8 @@ Then walk the user through the [Post-Setup Checklist](./post-setup-checklist.md)
 
 - If user is using Alby Cloud, setup is NOT needed. Human will complete setup manually.
 - Run `setup` only once. Re-running it on an already-initialised hub will fail.
-- The default backend is LDK. Pass `--backend` only for non-LDK backends (LND, Phoenixd, Cashu).
+- The default backend is LDK. Pass `--backend` only for non-LDK backends (LND, Phoenixd, Cashu, Bark).
+- A `BARK` (Ark) hub needs no channels — funds are usable right after setup, so skip the LSP / channel-opening steps above for it. See [Bark (Ark)](./bark.md).
 - After a machine restart, run `start` again to relaunch the node and get a fresh token.
 - Use `--save` so the token is persisted to `~/.hub-cli/token.jwt` and subsequent commands can authenticate automatically.
 - See [Authentication](./authentication.md) for token management details.


### PR DESCRIPTION
Documents the `BARK` (Ark) backend so the agent can set up and reason about Ark-based hubs.

## Changes
- **`references/bark.md`** (new) — setup, env-var configuration (`BARK_SERVER`, `BARK_ESPLORA_SERVER`, `BARK_SERVER_ACCESS_TOKEN`, `BARK_LOG_LEVEL`), beta status, and limitations (no channels, no on-chain, periodic VTXO refresh fees, recovery phrase alone is insufficient, requires persistent storage, supported NWC methods).
- **`references/backends.md`** — adds `BARK` to the supported-backends table, linking to `bark.md`.
- **`references/initial-setup.md`** — notes that a `BARK` hub needs no channels, so the LSP / channel-opening flow should be skipped.
- **`SKILL.md`** — adds `bark.md` to the references and mentions Bark in the default-backend rule.

Detail lives in the dedicated `bark.md`; top-level files stay lean (progressive disclosure).

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)