### PR TITLE
fix: repair broken CLI examples + document app vs wallet balance (#27)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: Manage a self-custodial Alby Hub lightning node via @getalby/hub-cl
 license: Apache-2.0
 metadata:
   author: getAlby
-  version: "0.1.2"
+  version: "0.1.3"
 ---
 
 # Alby Hub Agent Skill

--- a/references/alby-account.md
+++ b/references/alby-account.md
@@ -15,7 +15,7 @@ Connecting requires two steps:
 **Step 1** — Get the authorization URL:
 
 ```bash
-npx -y @getalby/hub-cli@0.4.0 hub-cli connect-alby-account
+npx -y @getalby/hub-cli@0.5.0 connect-alby-account
 ```
 
 This returns a JSON object with an `albyAuthUrl`. Tell the user to open that URL in their browser, sign in to their Alby account, and copy the authorization code they receive.
@@ -23,7 +23,7 @@ This returns a JSON object with an `albyAuthUrl`. Tell the user to open that URL
 **Step 2** — Submit the authorization code:
 
 ```bash
-npx -y @getalby/hub-cli@0.4.0 hub-cli connect-alby-account --code <code>
+npx -y @getalby/hub-cli@0.5.0 connect-alby-account --code <code>
 ```
 
 On success, returns `{ "success": true }`. If the account is already connected, step 1 returns `{ "albyAccountConnected": true, "albyUserIdentifier": "..." }` instead of a URL.

--- a/references/alby-cloud.md
+++ b/references/alby-cloud.md
@@ -15,8 +15,8 @@ The human must subscribe to Alby Cloud at https://getalby.com/subscription/new a
    ```
 3. The CLI auto-uses `https://my.albyhub.com` and sets the required routing headers. Use `start`/`unlock` as normal:
    ```bash
-   npx -y @getalby/hub-cli@0.4.0 hub-cli start --password YOUR_PASSWORD --save
-   npx -y @getalby/hub-cli@0.4.0 hub-cli balances
+   npx -y @getalby/hub-cli@0.5.0 start --password YOUR_PASSWORD --save
+   npx -y @getalby/hub-cli@0.5.0 get-balances
    ```
 
 To override the hub name for a single invocation, set the `ALBY_HUB_NAME` env var.

--- a/references/apps.md
+++ b/references/apps.md
@@ -6,20 +6,42 @@ Commands for managing NWC (Nostr Wallet Connect) app connections. NWC apps allow
 
 ```bash
 # List NWC app connections
-npx -y @getalby/hub-cli@0.4.0 hub-cli apps
+npx -y @getalby/hub-cli@0.5.0 list-apps
+
+# Look up a single app by name (prefix match) — the response includes its balance
+npx -y @getalby/hub-cli@0.5.0 list-apps --name "My App"
 
 # Create a new NWC connection with default permissions
-npx -y @getalby/hub-cli@0.4.0 hub-cli create-app --name "My App"
+npx -y @getalby/hub-cli@0.5.0 create-app --name "My App"
 
 # Create with custom scopes and a spending budget
-npx -y @getalby/hub-cli@0.4.0 hub-cli create-app --name "My App" \
+npx -y @getalby/hub-cli@0.5.0 create-app --name "My App" \
   --scopes "pay_invoice,get_balance" \
   --max-amount 10000 \
   --budget-renewal monthly
 
 # Create an isolated sub-wallet app (separate balance)
-npx -y @getalby/hub-cli@0.4.0 hub-cli create-app --name "Isolated App" --isolated --unlock-password YOUR_PASSWORD
+npx -y @getalby/hub-cli@0.5.0 create-app --name "Isolated App" --isolated --unlock-password YOUR_PASSWORD
 ```
+
+## App Balance vs. Wallet Balance
+
+There are **two different balances** — do not confuse them:
+
+- **Hub wallet balance** — the node's spendable lightning + on-chain funds, shared by all non-isolated apps. Get it with `get-balances`. See [Payments](./payments.md).
+- **App balance** — the isolated balance held by a single **isolated app** or **sub-wallet**. Non-isolated (shared-balance) apps spend directly from the hub wallet and have no balance of their own (their `balanceSat` is `0`).
+
+When a user asks for **"the balance of `<app name>`"**, they mean the app balance — **not** the hub wallet balance. Fetch the app by name and read its `balanceSat`:
+
+```bash
+# The response's `apps` array contains the matching app(s); read `balanceSat` from it
+npx -y @getalby/hub-cli@0.5.0 list-apps --name "Alice"
+```
+
+- `balanceSat` (satoshis) is the app/sub-wallet balance. `balanceMsat` is the same value in millisatoshis; the legacy `balance` field is millisatoshis and deprecated — prefer `balanceSat`.
+- `--name` is a **prefix** match and may return more than one app. Confirm the exact `name` field in the results before reporting a balance.
+- If no app matches, `apps` is empty — tell the user no app by that name exists. Do **not** fall back to reporting the hub wallet balance as if it were the app's.
+- For a shared (non-isolated) app, `balanceSat` is `0`; if the user wants the funds that app can spend, that is the hub wallet balance (`get-balances`).
 
 ## After Creating an App
 
@@ -30,6 +52,6 @@ After `create-app` succeeds, offer to display the `nostrWalletConnectUrl` (NWC c
 ## Notes
 
 - `create-app` returns a `nostrWalletConnectUrl` (NWC connection string) that the external app uses to connect.
-- Isolated apps have their own sub-wallet balance separate from the main hub wallet.
+- Isolated apps and sub-wallets have their own balance, separate from the main hub wallet — see [App Balance vs. Wallet Balance](#app-balance-vs-wallet-balance) above.
 - `--budget-renewal` accepts: `daily`, `weekly`, `monthly`, `yearly`, `never`.
 - Available scopes include: `pay_invoice`, `get_balance`, `get_info`, `make_invoice`, `lookup_invoice`, `list_transactions`, `sign_message`.

--- a/references/authentication.md
+++ b/references/authentication.md
@@ -6,20 +6,20 @@ Most commands require a JWT token. Tokens are obtained via `start` or `unlock` a
 
 ```bash
 # Start the node and save the JWT token (use after setup or machine restart)
-npx -y @getalby/hub-cli@0.4.0 hub-cli start --password YOUR_PASSWORD --save
+npx -y @getalby/hub-cli@0.5.0 start --password YOUR_PASSWORD --save
 
 # Get a fresh token for an already-running hub (no node restart)
-npx -y @getalby/hub-cli@0.4.0 hub-cli unlock --password YOUR_PASSWORD --save
+npx -y @getalby/hub-cli@0.5.0 unlock --password YOUR_PASSWORD --save
 
 # Get a readonly token
-npx -y @getalby/hub-cli@0.4.0 hub-cli unlock --password YOUR_PASSWORD --permission readonly --save
+npx -y @getalby/hub-cli@0.5.0 unlock --password YOUR_PASSWORD --permission readonly --save
 
 # Pass token inline (highest priority)
-npx -y @getalby/hub-cli@0.4.0 hub-cli balances -t eyJ...
+npx -y @getalby/hub-cli@0.5.0 get-balances -t eyJ...
 
 # Use environment variable
 export HUB_TOKEN="eyJ..."
-npx -y @getalby/hub-cli@0.4.0 hub-cli balances
+npx -y @getalby/hub-cli@0.5.0 get-balances
 ```
 
 ## Token Priority

--- a/references/backends.md
+++ b/references/backends.md
@@ -15,11 +15,11 @@ Alby Hub supports multiple lightning backends. The backend is chosen once during
 
 ```bash
 # Set up with the default LDK backend (--backend can be omitted)
-npx -y @getalby/hub-cli@0.4.0 hub-cli setup --password YOUR_PASSWORD
+npx -y @getalby/hub-cli@0.5.0 setup --password YOUR_PASSWORD
 
 # Set up with LND backend (requires LND_CERT_FILE and LND_MACAROON_FILE env vars)
-npx -y @getalby/hub-cli@0.4.0 hub-cli setup --password YOUR_PASSWORD --backend LND --lnd-address localhost:10009
+npx -y @getalby/hub-cli@0.5.0 setup --password YOUR_PASSWORD --backend LND --lnd-address localhost:10009
 
 # Restore LDK from an existing mnemonic
-npx -y @getalby/hub-cli@0.4.0 hub-cli setup --password YOUR_PASSWORD --mnemonic "word1 word2 ..."
+npx -y @getalby/hub-cli@0.5.0 setup --password YOUR_PASSWORD --mnemonic "word1 word2 ..."
 ```

--- a/references/channels.md
+++ b/references/channels.md
@@ -6,28 +6,28 @@ Commands for managing lightning channels and peers, including opening, closing, 
 
 ```bash
 # List lightning channels
-npx -y @getalby/hub-cli@0.4.0 hub-cli list-channels
+npx -y @getalby/hub-cli@0.5.0 list-channels
 
 # Get your node's connection info (pubkey, address, port)
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-node-connection-info
+npx -y @getalby/hub-cli@0.5.0 get-node-connection-info
 
 # List connected peers
-npx -y @getalby/hub-cli@0.4.0 hub-cli list-peers
+npx -y @getalby/hub-cli@0.5.0 list-peers
 
 # Connect to a lightning peer
-npx -y @getalby/hub-cli@0.4.0 hub-cli connect-peer --pubkey <pubkey> --address <host> --port <port>
+npx -y @getalby/hub-cli@0.5.0 connect-peer --pubkey <pubkey> --address <host> --port <port>
 
 # Open a private outbound channel to a peer (requires on-chain funds)
-npx -y @getalby/hub-cli@0.4.0 hub-cli open-channel --pubkey <pubkey> --amount-sats 500000
+npx -y @getalby/hub-cli@0.5.0 open-channel --pubkey <pubkey> --amount-sats 500000
 
 # Open a public outbound channel
-npx -y @getalby/hub-cli@0.4.0 hub-cli open-channel --pubkey <pubkey> --amount-sats 500000 --public
+npx -y @getalby/hub-cli@0.5.0 open-channel --pubkey <pubkey> --amount-sats 500000 --public
 
 # Close a channel cooperatively
-npx -y @getalby/hub-cli@0.4.0 hub-cli close-channel --peer-id <pubkey> --channel-id <id>
+npx -y @getalby/hub-cli@0.5.0 close-channel --peer-id <pubkey> --channel-id <id>
 
 # Force-close a channel
-npx -y @getalby/hub-cli@0.4.0 hub-cli close-channel --peer-id <pubkey> --channel-id <id> --force
+npx -y @getalby/hub-cli@0.5.0 close-channel --peer-id <pubkey> --channel-id <id> --force
 ```
 
 ## After Opening a Channel
@@ -35,7 +35,7 @@ npx -y @getalby/hub-cli@0.4.0 hub-cli close-channel --peer-id <pubkey> --channel
 After opening a channel (either outbound or via LSP), immediately run `list-channels` and report the confirmation status to the user:
 
 ```bash
-npx -y @getalby/hub-cli@0.4.0 hub-cli list-channels
+npx -y @getalby/hub-cli@0.5.0 list-channels
 ```
 
 Look at the `confirmations` and `confirmationsRequired` fields on the new channel and tell the user: how many confirmations are required, and how many have been received so far. This sets expectations — the channel won't be usable until fully confirmed.

--- a/references/hub-management.md
+++ b/references/hub-management.md
@@ -6,28 +6,28 @@ Commands for monitoring hub health, status, stopping the lightning node, and man
 
 ```bash
 # Hub status, version, and backend type
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-info
+npx -y @getalby/hub-cli@0.5.0 get-info
 
 # Lightning node readiness check
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-node-status
+npx -y @getalby/hub-cli@0.5.0 get-node-status
 
 # Health check with active alarms
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-health
+npx -y @getalby/hub-cli@0.5.0 get-health
 
 # Stop the lightning node (hub HTTP server keeps running)
-npx -y @getalby/hub-cli@0.4.0 hub-cli stop
+npx -y @getalby/hub-cli@0.5.0 stop
 
 # Trigger a wallet sync
-npx -y @getalby/hub-cli@0.4.0 hub-cli sync
+npx -y @getalby/hub-cli@0.5.0 sync
 
 # Export wallet recovery phrase to a file
-npx -y @getalby/hub-cli@0.4.0 hub-cli backup --password YOUR_PASSWORD
+npx -y @getalby/hub-cli@0.5.0 backup-mnemonic --password YOUR_PASSWORD
 
 # Export to a custom path
-npx -y @getalby/hub-cli@0.4.0 hub-cli backup --password YOUR_PASSWORD --output /path/to/backup.recovery
+npx -y @getalby/hub-cli@0.5.0 backup-mnemonic --password YOUR_PASSWORD --output /path/to/backup.recovery
 
 # Change the hub unlock password
-npx -y @getalby/hub-cli@0.4.0 hub-cli change-password \
+npx -y @getalby/hub-cli@0.5.0 change-password \
   --current-password YOUR_PASSWORD \
   --confirm-current-password YOUR_PASSWORD \
   --new-password NEW_PASSWORD

--- a/references/initial-setup.md
+++ b/references/initial-setup.md
@@ -8,14 +8,14 @@ The first-time setup flow initialises the hub and starts the lightning node. `se
 
 ```bash
 # Step 1: Initialise the hub (one-time only) — LDK backend is the default
-npx -y @getalby/hub-cli@0.4.0 hub-cli setup --password YOUR_PASSWORD
+npx -y @getalby/hub-cli@0.5.0 setup --password YOUR_PASSWORD
 
 # Step 2: Start the node and save the JWT token to disk
-npx -y @getalby/hub-cli@0.4.0 hub-cli start --password YOUR_PASSWORD --save
+npx -y @getalby/hub-cli@0.5.0 start --password YOUR_PASSWORD --save
 
 # Verify the node is running
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-info
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-node-status
+npx -y @getalby/hub-cli@0.5.0 get-info
+npx -y @getalby/hub-cli@0.5.0 get-node-status
 ```
 
 > **Password privacy:** Do not ask the user to share their password in the conversation. Instead, tell the user the command to run themselves (substituting `YOUR_PASSWORD`), or acknowledge that the password will be visible in the terminal/shell history. Only accept the password in-chat if the user explicitly volunteers it. The user can also change their password later. Or, if you're running a local model, you can give me the password directly in the chat.
@@ -26,14 +26,14 @@ After setup, the recommended first step is opening a channel via an LSP — no o
 
 ```bash
 # See available LSPs — returned in priority order, filter to your active network
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-channel-suggestions
+npx -y @getalby/hub-cli@0.5.0 get-channel-suggestions
 
 # Ask the user for their preferred channel size (suggest 500,000 sats as default)
 # Use the first LSP in the list that you don't already have a channel with
-npx -y @getalby/hub-cli@0.4.0 hub-cli request-lsp-order --amount 500000 --lsp-type <type> --lsp-identifier <identifier>
+npx -y @getalby/hub-cli@0.5.0 request-lsp-order --amount 500000 --lsp-type <type> --lsp-identifier <identifier>
 
 # Pay the invoice to open the channel (or have a human pay it on testnet)
-npx -y @getalby/hub-cli@0.4.0 hub-cli pay-invoice <invoice>
+npx -y @getalby/hub-cli@0.5.0 pay-invoice <invoice>
 ```
 
 See [LSP](./lsp.md) for full details.

--- a/references/lsp.md
+++ b/references/lsp.md
@@ -6,29 +6,29 @@ LSP (Lightning Service Provider) commands are the **recommended way to get start
 
 ```bash
 # List available LSP providers with fees and channel size limits
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-channel-suggestions
+npx -y @getalby/hub-cli@0.5.0 get-channel-suggestions
 
 # Request a lightning invoice from an LSP to open an inbound channel
-npx -y @getalby/hub-cli@0.4.0 hub-cli request-lsp-order --amount <sats> --lsp-type <type> --lsp-identifier <identifier>
+npx -y @getalby/hub-cli@0.5.0 request-lsp-order --amount <sats> --lsp-type <type> --lsp-identifier <identifier>
 
 # Pay the LSP invoice to trigger channel opening (mainnet, requires funded wallet)
-npx -y @getalby/hub-cli@0.4.0 hub-cli pay-invoice <invoice>
+npx -y @getalby/hub-cli@0.5.0 pay-invoice <invoice>
 
 # Request an Alby LSP channel offer (requires a linked Alby account)
-npx -y @getalby/hub-cli@0.4.0 hub-cli request-alby-lsp-channel-offer
+npx -y @getalby/hub-cli@0.5.0 request-alby-lsp-channel-offer
 ```
 
 ## Typical LSP Channel Flow
 
 ```bash
 # 1. List available LSPs (returned in priority order)
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-channel-suggestions
+npx -y @getalby/hub-cli@0.5.0 get-channel-suggestions
 
 # 2. Request an invoice from the chosen LSP
-npx -y @getalby/hub-cli@0.4.0 hub-cli request-lsp-order --amount <sats> --lsp-type <type> --lsp-identifier <identifier>
+npx -y @getalby/hub-cli@0.5.0 request-lsp-order --amount <sats> --lsp-type <type> --lsp-identifier <identifier>
 
 # 3. Pay the invoice to open the channel
-npx -y @getalby/hub-cli@0.4.0 hub-cli pay-invoice <invoice>
+npx -y @getalby/hub-cli@0.5.0 pay-invoice <invoice>
 ```
 
 ## Choosing an LSP

--- a/references/mutinynet.md
+++ b/references/mutinynet.md
@@ -27,11 +27,11 @@ Do **not** redirect stdout. Logs are written to `{WORK_DIR}/log/nwc.log`.
 
 ```bash
 # Initialise and start the hub (LDK is the default backend)
-npx -y @getalby/hub-cli@0.4.0 hub-cli setup --password YOUR_PASSWORD
-npx -y @getalby/hub-cli@0.4.0 hub-cli start --password YOUR_PASSWORD --save
+npx -y @getalby/hub-cli@0.5.0 setup --password YOUR_PASSWORD
+npx -y @getalby/hub-cli@0.5.0 start --password YOUR_PASSWORD --save
 
 # Verify the node is running
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-info
+npx -y @getalby/hub-cli@0.5.0 get-info
 ```
 
 ## Getting Inbound Capacity (Recommended Path)
@@ -40,10 +40,10 @@ Opening a channel via an LSP is the recommended first step — no on-chain depos
 
 ```bash
 # List available LSPs — filter results to signet/Mutinynet entries only
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-channel-suggestions
+npx -y @getalby/hub-cli@0.5.0 get-channel-suggestions
 
 # Request an invoice from the chosen LSP
-npx -y @getalby/hub-cli@0.4.0 hub-cli request-lsp-order --amount 500000 --lsp-type <type> --lsp-identifier <identifier>
+npx -y @getalby/hub-cli@0.5.0 request-lsp-order --amount 500000 --lsp-type <type> --lsp-identifier <identifier>
 ```
 
 Print the invoice as a **single unbroken line** so the user can copy-paste it easily. If the terminal may wrap it, offer to write it to a file.
@@ -55,7 +55,7 @@ The LSP invoice must be paid manually via https://faucet.mutinynet.com — the a
 If an on-chain deposit is needed instead:
 
 ```bash
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-onchain-address
+npx -y @getalby/hub-cli@0.5.0 get-onchain-address
 ```
 
 Visit https://faucet.mutinynet.com to send test sats to the address.

--- a/references/overview.md
+++ b/references/overview.md
@@ -6,16 +6,16 @@ Alby Hub is a self-custodial lightning node you run yourself. The `@getalby/hub-
 
 ```bash
 # Show help
-npx -y @getalby/hub-cli@0.4.0 hub-cli --help
+npx -y @getalby/hub-cli@0.5.0 --help
 
 # Hub status, version, backend type
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-info
+npx -y @getalby/hub-cli@0.5.0 get-info
 
 # Lightning node readiness
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-node-status
+npx -y @getalby/hub-cli@0.5.0 get-node-status
 
 # Health check with active alarms
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-health
+npx -y @getalby/hub-cli@0.5.0 get-health
 ```
 
 ## Global Options

--- a/references/payments.md
+++ b/references/payments.md
@@ -6,31 +6,31 @@ Commands for sending and receiving lightning payments, checking balances, and qu
 
 ```bash
 # Lightning + on-chain balances
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-balances
+npx -y @getalby/hub-cli@0.5.0 get-balances
 
 # Get an on-chain deposit address
-npx -y @getalby/hub-cli@0.4.0 hub-cli get-onchain-address
+npx -y @getalby/hub-cli@0.5.0 get-onchain-address
 
 # Pay a BOLT11 invoice
-npx -y @getalby/hub-cli@0.4.0 hub-cli pay-invoice lnbc...
+npx -y @getalby/hub-cli@0.5.0 pay-invoice lnbc...
 
 # Pay a zero-amount invoice, specifying the amount in millisatoshis
-npx -y @getalby/hub-cli@0.4.0 hub-cli pay-invoice lnbc... --amount 1000
+npx -y @getalby/hub-cli@0.5.0 pay-invoice lnbc... --amount 1000
 
 # Pay a lightning address (user@domain)
-npx -y @getalby/hub-cli@0.4.0 hub-cli pay-lightning-address user@domain.com --amount 1000
+npx -y @getalby/hub-cli@0.5.0 pay-lightning-address user@domain.com --amount 1000
 
 # Create a BOLT11 invoice
-npx -y @getalby/hub-cli@0.4.0 hub-cli make-invoice --amount 1000 --description "test"
+npx -y @getalby/hub-cli@0.5.0 make-invoice --amount 1000 --description "test"
 
 # List recent payments
-npx -y @getalby/hub-cli@0.4.0 hub-cli list-transactions
+npx -y @getalby/hub-cli@0.5.0 list-transactions
 
 # List with pagination
-npx -y @getalby/hub-cli@0.4.0 hub-cli list-transactions --limit 50 --offset 0
+npx -y @getalby/hub-cli@0.5.0 list-transactions --limit 50 --offset 0
 
 # Look up a specific payment by payment hash
-npx -y @getalby/hub-cli@0.4.0 hub-cli lookup-transaction <paymentHash>
+npx -y @getalby/hub-cli@0.5.0 lookup-transaction <paymentHash>
 ```
 
 ## On-Chain Reserve Warning
@@ -44,4 +44,4 @@ After running `get-balances`, check the on-chain balance. If `lightning.totalSpe
 - `--amount` for `pay-invoice` is in millisatoshis (msat). Use for zero-amount invoices only.
 - `--amount` for `make-invoice` is in millisatoshis.
 - `--amount` for `pay-lightning-address` is in satoshis.
-- `get-balances` returns both lightning (channel) and on-chain balances.
+- `get-balances` returns both lightning (channel) and on-chain balances. This is the **hub wallet** balance — it is **not** the balance of any individual app.


### PR DESCRIPTION
Fixes #27.

## What went wrong

Asking "what is the balance of `<app name>`" failed for two reasons:

1. **Every command example was broken.** Reference files used `npx -y @getalby/hub-cli@0.4.0 hub-cli <cmd>` — the stray `hub-cli` token makes the CLI exit with `error: unknown command 'hub-cli'`. So *every* documented command failed.
2. **No app-balance guidance.** Nothing explained that an app's balance is a different thing from the hub wallet balance, or how to fetch it.

## Changes

- **Repair broken invocations** across all 12 reference files — drop the stray `hub-cli` token.
- **Fix stale command names** (verified against the real CLI): `apps` → `list-apps`, `balances` → `get-balances`, `backup` → `backup-mnemonic`.
- **New "App Balance vs. Wallet Balance" section** in `apps.md`: the app balance (isolated apps / sub-wallets) is fetched by name with `list-apps --name` and read from `balanceSat`; the hub wallet balance (`get-balances`) is a separate thing; a non-isolated app has `balanceSat: 0`; an empty result must not be reported as the wallet balance. Cross-linked from `payments.md`.
- **Version pins bumped to `@0.5.0`** consistently — the hub-cli release that ships `list-apps --name`. Skill version `0.1.2` → `0.1.3`.

## Depends on

getAlby/hub-cli#21 (adds `list-apps --name`). **Release hub-cli `0.5.0` before merging this**, since the skill now pins `@0.5.0`. If the release lands under a different version number, update the pins to match.

## Not fixed here (separate issue)

`payments.md` documents `pay-lightning-address user@domain.com`, but no such command exists — the CLI only has `request-invoice-from-lightning-address` (requests an invoice, doesn't pay). That's a functionality gap, not a rename, so it's left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)