### PR TITLE
Fix: choose systemd

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: Manage a self-custodial Alby Hub lightning node via @getalby/hub-cl
 license: Apache-2.0
 metadata:
   author: getAlby
-  version: "0.1.3"
+  version: "0.1.4"
 ---
 
 # Alby Hub Agent Skill
@@ -17,7 +17,7 @@ Use this skill to manage an Alby Hub lightning node via the CLI.
 
 > **Hub management vs. payments.** This skill is optimized for _managing the hub_ — setup, channels, LSP, NWC app creation, backups. A core hub strength is minting **multiple budgeted, scoped NWC connections** — one per app or purpose — so the user stays in control and each connection's blast radius is small. Once an NWC connection exists (via `create-app`), the [`alby-bitcoin-payments`](https://getalby.com/payments/SKILL.md) skill is the better fit for _using_ it — budgeted payments, 402 paid APIs, HOLD invoices, keysend, lightning address lookups, and fiat/sats conversion.
 
-- [Installation: How to get Alby Hub running — cloud, Linux, Docker, Raspberry Pi, desktop](./references/installation.md)
+- [Installation: How to get Alby Hub running — Linux, Docker, Raspberry Pi, desktop](./references/installation.md)
 - [Overview: What Alby Hub is and how the CLI fits in](./references/overview.md)
 - [Backends: LDK, LND, Phoenixd, Cashu, Bark — features and configuration](./references/backends.md)
 - [Bark (Ark): Setup, env-var config, and limitations of the Ark-based backend](./references/bark.md)

--- a/references/bark.md
+++ b/references/bark.md
@@ -6,10 +6,10 @@ Bark is an [Ark](https://second.tech/) client backend. Instead of opening lightn
 
 ## Setup
 
-Bark is configured entirely through environment variables read by the hub at startup — it has no CLI flags. Set the env vars on the hub **before** running `setup`. The mnemonic is generated automatically; do not pass `--mnemonic`.
+Bark has no CLI flags of its own — it's configured via environment variables read by the hub at startup, but the mainnet defaults work out of the box, so you only need `--backend BARK`. The mnemonic is generated automatically; do not pass `--mnemonic`.
 
 ```bash
-npx -y @getalby/hub-cli@0.4.0 hub-cli setup --password YOUR_PASSWORD --backend BARK
+npx -y @getalby/hub-cli@0.5.0 setup --password YOUR_PASSWORD --backend BARK
 ```
 
 The backend is fixed at setup time and cannot be changed afterwards without re-initialising the hub.
@@ -19,8 +19,8 @@ The backend is fixed at setup time and cannot be changed afterwards without re-i
 | Env var | Default | Purpose |
 | ------- | ------- | ------- |
 | `LN_BACKEND_TYPE` | — | Set to `BARK` (or pass `--backend BARK` to `setup`) |
-| `BARK_SERVER` | `https://ark.second.tech` | Ark server URL. For signet use `https://ark.signet.2nd.dev` |
-| `BARK_ESPLORA_SERVER` | `https://mempool.second.tech/api` | Esplora server URL for chain data. For signet use `https://esplora.signet.2nd.dev` |
+| `BARK_SERVER` | `https://ark.second.tech` | Ark server URL |
+| `BARK_ESPLORA_SERVER` | `https://mempool.second.tech/api` | Esplora server URL for chain data |
 | `BARK_SERVER_ACCESS_TOKEN` | (none) | Optional — only required for a private Ark server |
 | `BARK_LOG_LEVEL` | `3` | Bark-specific log verbosity (higher is more verbose). Separate from the main app log level |
 

--- a/references/installation.md
+++ b/references/installation.md
@@ -2,11 +2,13 @@
 
 How to get Alby Hub running. Once it's up, use the CLI to manage it — see [Initial Setup](./initial-setup.md) for the first-time setup flow.
 
-## Alby Cloud (Managed Hosting)
+## Recommended: systemd service (Linux)
 
-See [Alby Cloud](./alby-cloud.md).
+On a Linux server, **the default and recommended way to install Alby Hub is the systemd install script** ([x86_64](#linux-x86_64-recommended-for-servers) / [aarch64](#linux-aarch64-arm64-servers)). It installs the hub as a service that starts automatically on boot and is restarted on failure. Do **not** reach for the manual binary install or write your own systemd unit unless the user explicitly asks for a throwaway/test setup — see [HTTP Server Binary (manual)](#linux-x86_64--aarch64--http-server-binary-manual---not-recommended).
 
-## Linux x86_64 (Recommended for Servers)
+**This is the default for every backend**. A backend that needs extra environment variables does not change this; set those on the systemd unit rather than dropping to a manual binary install (see [Configuring env vars for a systemd install](#configuring-env-vars-for-a-systemd-install)).
+
+### Linux x86_64
 
 Installs as a systemd service that starts automatically on boot.
 
@@ -22,7 +24,7 @@ Default port: `http://localhost:8029`
 
 To update later: run `./update.sh` in the install directory. Backup data lives in `[install path]/data`.
 
-## Linux aarch64 (ARM64 Servers)
+### Linux aarch64 (ARM64 Servers)
 
 Installs as a systemd service that starts automatically on boot. Same approach as x86_64, different script:
 
@@ -34,7 +36,36 @@ Flags: `-y` non-interactive, `--skip-verify` skip PGP signature verification, `-
 
 After the script completes, verify with `systemctl status albyhub`. If the script fails, diagnose and fix the specific error then re-run it — do **not** fall back to a manual binary install or create your own systemd service.
 
+### Configuring env vars for a systemd install
+
+**This is not needed by default. Only add env vars if the user explicitly specifies them.**
+
+The systemd install runs the hub from a fixed working directory, so a `.env` file is **not** read. Any backend or configuration that needs extra environment variables (e.g. LND credential paths, a custom `MEMPOOL_API` or `LDK_ESPLORA_SERVER`) must have those vars set on the systemd unit, **before** running `setup`.
+
+Add a drop-in override and restart:
+
+```bash
+sudo systemctl edit albyhub
+```
+
+In the editor, add (one `Environment=` line per var):
+
+```ini
+[Service]
+Environment="KEY=value"
+```
+
+Then apply and restart:
+
+```bash
+sudo systemctl restart albyhub
+```
+
+Data (database, keys, logs) stays in `[install dir]/data` — the persistent location the install script configures — so there is no need for `WORK_DIR=.`. See [Backends](./backends.md) for which vars each backend needs.
+
 ## Linux x86_64 / aarch64 — HTTP Server Binary (Manual - not recommended)
+
+> **Only use this if the user explicitly asks for a manual / no-systemd / throwaway test setup.** For any normal install, on any backend, use the [systemd service](#recommended-systemd-service-linux) instead. Do not pick this path just because a backend needs env vars; configure those on the systemd unit (see [below](#configuring-env-vars-for-a-systemd-install)).
 
 For testing or running in a specific folder without systemd. The binary starts an HTTP server you manage yourself.
 
@@ -117,7 +148,7 @@ Install via your node OS app store.
 | Backend                  | RAM                          | Disk    |
 | ------------------------ | ---------------------------- | ------- |
 | LDK (default)            | 2 GB (or 512 MB + 2 GB swap) | 1 GB+   |
-| External (LND, Phoenixd) | 256 MB                       | Minimal |
+| Others                   | 256 MB                       | Minimal |
 
 lightning port 9735 should be open and reachable for optimal channel connectivity.
 
@@ -125,5 +156,5 @@ lightning port 9735 should be open and reachable for optimal channel connectivit
 
 After installation, the hub is available at:
 
-- `http://localhost:8080` — Docker, desktop app, manual binary
 - `http://localhost:8029` — systemd install scripts
+- `http://localhost:8080` — Docker, desktop app, manual binary

--- a/references/installation.md
+++ b/references/installation.md
@@ -4,7 +4,7 @@ How to get Alby Hub running. Once it's up, use the CLI to manage it — see [Ini
 
 ## Recommended: systemd service (Linux)
 
-On a Linux server, **the default and recommended way to install Alby Hub is the systemd install script** ([x86_64](#linux-x86_64-recommended-for-servers) / [aarch64](#linux-aarch64-arm64-servers)). It installs the hub as a service that starts automatically on boot and is restarted on failure. Do **not** reach for the manual binary install or write your own systemd unit unless the user explicitly asks for a throwaway/test setup — see [HTTP Server Binary (manual)](#linux-x86_64--aarch64--http-server-binary-manual---not-recommended).
+On a Linux server, **the default and recommended way to install Alby Hub is the systemd install script** ([x86_64](#linux-x86_64) / [aarch64](#linux-aarch64-arm64-servers)). It installs the hub as a service that starts automatically on boot and is restarted on failure.
 
 **This is the default for every backend**. A backend that needs extra environment variables does not change this; set those on the systemd unit rather than dropping to a manual binary install (see [Configuring env vars for a systemd install](#configuring-env-vars-for-a-systemd-install)).
 
@@ -63,85 +63,9 @@ sudo systemctl restart albyhub
 
 Data (database, keys, logs) stays in `[install dir]/data` — the persistent location the install script configures — so there is no need for `WORK_DIR=.`. See [Backends](./backends.md) for which vars each backend needs.
 
-## Linux x86_64 / aarch64 — HTTP Server Binary (Manual - not recommended)
+## Other installation options
 
-> **Only use this if the user explicitly asks for a manual / no-systemd / throwaway test setup.** For any normal install, on any backend, use the [systemd service](#recommended-systemd-service-linux) instead. Do not pick this path just because a backend needs env vars; configure those on the systemd unit (see [below](#configuring-env-vars-for-a-systemd-install)).
-
-For testing or running in a specific folder without systemd. The binary starts an HTTP server you manage yourself.
-
-**Download the latest release:**
-
-```bash
-# Asset filenames follow this pattern — use the one matching your architecture:
-#   albyhub-Server-Linux-x86_64.tar.bz2   (x86_64)
-#   albyhub-Server-Linux-aarch64.tar.bz2  (ARM64)
-curl -L --no-progress-meter -o albyhub.tar.bz2 \
-  https://github.com/getAlby/hub/releases/latest/download/albyhub-Server-Linux-x86_64.tar.bz2
-tar -xjf albyhub.tar.bz2
-```
-
-The binary is at `bin/albyhub`.
-
-**Configuration via `.env` file:**
-
-Hub reads a `.env` file in the working directory automatically — do not pass env vars inline and do not `source` the file manually. Create `.env` before starting.
-
-**Ask the user** whether they want to use the default data directory (`~/.local/share/albyhub`) or keep data in the current folder. If they want data in the current folder, set `WORK_DIR=.` in the `.env`:
-
-```
-WORK_DIR=.
-# Add any other vars here, e.g. NETWORK, MEMPOOL_API, LDK_ESPLORA_SERVER
-```
-
-Setting `WORK_DIR=.` keeps all hub data (database, logs, keys) in the current folder.
-
-**Running the hub:**
-
-Run in the background — the hub manages its own logging:
-
-```bash
-./bin/albyhub &
-```
-
-Do **not** redirect stdout (e.g. `> albyhub.log`). Logs are written to `{WORK_DIR}/log/nwc.log`.
-
-Default port: `http://localhost:8080`
-
-## Raspberry Pi 4/5 (Experimental)
-
-```bash
-/bin/bash -c "$(curl -fsSL https://getalby.com/install/hub/pi-aarch64-install.sh)"
-```
-
-Installs to `/opt/albyhub`. Update via `./update.sh`. Official support is limited for this platform.
-
-## Docker
-
-```bash
-docker run -v ~/.local/share/albyhub:/data \
-  -e WORK_DIR='/data' \
-  -p 8080:8080 \
-  ghcr.io/getalby/hub:latest
-```
-
-Docker Compose file: https://raw.githubusercontent.com/getAlby/hub/master/docker-compose.yml
-
-Default port: `http://localhost:8080`
-
-## Desktop App (Mac / Windows / Linux)
-
-> **Warning:** Do not suggest the desktop app to users working with an agent. Agents cannot control or interact with the desktop GUI. Use one of the server/binary options above instead.
-
-Download the latest release for your platform from https://github.com/getAlby/hub/releases/latest.
-
-Platforms: Mac (arm64), Windows (amd64), Linux (amd64). Designed to run 24/7 on an always-online machine.
-
-## Node Distributions (Umbrel / Start9)
-
-- **Umbrel**: https://github.com/getAlby/umbrel-community-app-store
-- **Start9**: https://github.com/horologger/nostr-wallet-connect-startos
-
-Install via your node OS app store.
+Manual binary, Docker, Raspberry Pi, desktop app, and Umbrel/Start9 — see [Other installation options](./other-installation-options.md).
 
 ## System Requirements
 
@@ -151,10 +75,3 @@ Install via your node OS app store.
 | Others                   | 256 MB                       | Minimal |
 
 lightning port 9735 should be open and reachable for optimal channel connectivity.
-
-## Default Hub URL
-
-After installation, the hub is available at:
-
-- `http://localhost:8029` — systemd install scripts
-- `http://localhost:8080` — Docker, desktop app, manual binary

--- a/references/other-installation-options.md
+++ b/references/other-installation-options.md
@@ -1,0 +1,83 @@
+# Other Installation Options
+
+Non-systemd ways to run Alby Hub. The recommended install is the [systemd service](./installation.md#recommended-systemd-service-linux) — only use the options below if the user explicitly asks for them.
+
+## Linux x86_64 / aarch64 — HTTP Server Binary (Manual - not recommended)
+
+> **Only use this if the user explicitly asks for a manual / no-systemd / throwaway test setup.** For any normal install, on any backend, use the [systemd service](./installation.md#recommended-systemd-service-linux) instead. Do not pick this path just because a backend needs env vars; configure those on the systemd unit (see [Configuring env vars for a systemd install](./installation.md#configuring-env-vars-for-a-systemd-install)).
+
+For testing or running in a specific folder without systemd. The binary starts an HTTP server you manage yourself.
+
+**Download the latest release:**
+
+```bash
+# Asset filenames follow this pattern — use the one matching your architecture:
+#   albyhub-Server-Linux-x86_64.tar.bz2   (x86_64)
+#   albyhub-Server-Linux-aarch64.tar.bz2  (ARM64)
+curl -L --no-progress-meter -o albyhub.tar.bz2 \
+  https://github.com/getAlby/hub/releases/latest/download/albyhub-Server-Linux-x86_64.tar.bz2
+tar -xjf albyhub.tar.bz2
+```
+
+The binary is at `bin/albyhub`.
+
+**Configuration via `.env` file:**
+
+Hub reads a `.env` file in the working directory automatically — do not pass env vars inline and do not `source` the file manually. Create `.env` before starting.
+
+**Ask the user** whether they want to use the default data directory (`~/.local/share/albyhub`) or keep data in the current folder. If they want data in the current folder, set `WORK_DIR=.` in the `.env`:
+
+```
+WORK_DIR=.
+# Add any other vars here, e.g. NETWORK, MEMPOOL_API, LDK_ESPLORA_SERVER
+```
+
+Setting `WORK_DIR=.` keeps all hub data (database, logs, keys) in the current folder.
+
+**Running the hub:**
+
+Run in the background — the hub manages its own logging:
+
+```bash
+./bin/albyhub &
+```
+
+Do **not** redirect stdout (e.g. `> albyhub.log`). Logs are written to `{WORK_DIR}/log/nwc.log`.
+
+Default port: `http://localhost:8080`
+
+## Raspberry Pi 4/5 (Experimental)
+
+```bash
+/bin/bash -c "$(curl -fsSL https://getalby.com/install/hub/pi-aarch64-install.sh)"
+```
+
+Installs to `/opt/albyhub`. Update via `./update.sh`. Official support is limited for this platform.
+
+## Docker
+
+```bash
+docker run -v ~/.local/share/albyhub:/data \
+  -e WORK_DIR='/data' \
+  -p 8080:8080 \
+  ghcr.io/getalby/hub:latest
+```
+
+Docker Compose file: https://raw.githubusercontent.com/getAlby/hub/master/docker-compose.yml
+
+Default port: `http://localhost:8080`
+
+## Desktop App (Mac / Windows / Linux)
+
+> **Warning:** Do not suggest the desktop app to users working with an agent. Agents cannot control or interact with the desktop GUI. Use one of the server/binary options above instead.
+
+Download the latest release for your platform from https://github.com/getAlby/hub/releases/latest.
+
+Platforms: Mac (arm64), Windows (amd64), Linux (amd64). Designed to run 24/7 on an always-online machine.
+
+## Node Distributions (Umbrel / Start9)
+
+- **Umbrel**: https://github.com/getAlby/umbrel-community-app-store
+- **Start9**: https://github.com/horologger/nostr-wallet-connect-startos
+
+Install via your node OS app store.


### PR DESCRIPTION
Fixes https://github.com/getAlby/hub-skill/issues/41

Also splits up installation reference and fixes CLI version and no longer recommends cloud (agents should run alby hub themselves).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized installation guide with emphasis on Linux systemd service setup.
  * Added comprehensive guide for alternative installation options: Docker, Raspberry Pi, desktop app, and node distributions.
  * Clarified Bark setup instructions and updated configuration details.
  * Updated skill release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->